### PR TITLE
Added support for "get_deleted" option in nkelastic_search.

### DIFF
--- a/src/nkelastic_search.erl
+++ b/src/nkelastic_search.erl
@@ -147,7 +147,12 @@ query(Spec) ->
                     #{}
             end,
             % TODO Temporary hack
-            Query2 = Query1#{must_not => #{term => #{is_deleted=>true}}},
+            Query2 = case Spec of
+                #{get_deleted := true} ->
+                    Query1;
+                _ ->
+                    Query1#{must_not => #{term => #{is_deleted=>true}}}
+            end,
             Query3 = case maps:get(filters, Parsed, []) of
                 [] ->
                     Query2;


### PR DESCRIPTION
This will allow us to get deleted objects as possible results for objects/domain/find and objects/domain/find_all commands.